### PR TITLE
mysql-update: Updates to support mysql >= 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,33 @@ Arsenal is an operations database for tracking the lifecycle of physical and vir
 
 All with audit tracking to see what changed when, and by whom.
 
-Installation
+Build
 ------
 
-TBD. Need to get control of the python package on pypi.
+To build the client or server, you need a python 3.9 virtual environment as follows:
+
+```
+python3.9 -m venv ~/venvs/build_arsenal
+. ~/venvs/build_arsenal/bin/activate
+pip install --upgrade pip
+pip install setuptools wheel
+cd ~/git/arsenal/{client|server}
+```
+
+If you want to build a development build, do so by first running:
+
+```
+python setup.py setopt -c egg_info -o tag_build -s ".devX"
+```
+
+Where X is the development version number you wish to build (i.e. 1). Subsequent dev builds should increment by 1.
+
+To build the latest version:
+
+```
+git co main
+python setup.py bdist_wheel
+```
 
 Development
 ------
@@ -47,6 +70,18 @@ Import the schema and data.
 ```bash
 mysql -u root -p < ~/git/arsenal/server/arsenalweb/db/arsenal-schema.sql
 mysql -u root -p < ~/git/arsenal/server/arsenalweb/db/arsenal-data.sql
+```
+
+You will need additional packages in order to build mysqlclient. On a mac:
+
+```
+brew install mysql-client pkg-config
+```
+
+On Rocky Linux:
+
+```
+dnf install -y pkg-config mariadb-devel --enablerepo=devel
 ```
 
 ### Install the webapp

--- a/server/setup.py
+++ b/server/setup.py
@@ -42,7 +42,7 @@ requires = [
     'idna==2.10',
     'importlib-metadata==4.0.1',
     'iniconfig==1.1.1',
-    'mysqlclient==2.0.3',
+    'mysqlclient==2.2.4',
     'packaging==20.9',
     'pam==0.2.0',
     'passlib==1.7.4',

--- a/server/setup.py
+++ b/server/setup.py
@@ -89,7 +89,7 @@ tests_require = [
 
 setup(
     name='arsenalweb',
-    version='12.6.1',
+    version='12.7.0',
     description='Arsenal web api/ui',
     long_description=README + '\n\n' + CHANGES,
     classifiers=[

--- a/server/tests/regression/docker/mysql_init/data-init.sql
+++ b/server/tests/regression/docker/mysql_init/data-init.sql
@@ -39,33 +39,33 @@ INSERT INTO users VALUES (10, 'decom-hw', 'Bot user to decommission harware', 'B
 #
 # database groups
 ###########################################################################
-INSERT INTO groups VALUES (1, 'local_admin',               NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (2, 'api_write',                 NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (3, 'api_register',              NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (1, 'local_admin',               NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (2, 'api_write',                 NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (3, 'api_register',              NOW(), NOW(), 'Admin');
 # Set this to whatever system group you want to have admin access (wheel, arsenal_admins, etc.)
-INSERT INTO groups VALUES (4, 'arsenal_admins',            NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (4, 'arsenal_admins',            NOW(), NOW(), 'Admin');
 # For devel on mac
 # INSERT INTO groups VALUES (5, 'admin',                     NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (6, 'node_write',                NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (7, 'node_delete',               NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (8, 'node_group_write',          NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (9, 'node_group_delete',         NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (10,'tag_write',                 NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (11,'tag_delete',                NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (12,'data_center_write',         NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (13,'data_center_delete',        NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (6, 'node_write',                NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (7, 'node_delete',               NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (8, 'node_group_write',          NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (9, 'node_group_delete',         NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (10,'tag_write',                 NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (11,'tag_delete',                NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (12,'data_center_write',         NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (13,'data_center_delete',        NOW(), NOW(), 'Admin');
 # This is a special local group that is not assigned any permissions via route, but
 # members of this group will be able to write secure tags.
-INSERT INTO groups VALUES (14,'secure_tags',               NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (15,'physical_device_write',     NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (16,'physical_device_delete',    NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (17,'physical_location_write',   NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (18,'physical_location_delete',  NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (19,'physical_rack_write',       NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (20,'physical_rack_delete',      NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (21,'physical_elevation_write',  NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (22,'physical_elevation_delete', NOW(), NOW(), 'Admin');
-INSERT INTO groups VALUES (23,'status_write',              NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (14,'secure_tags',               NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (15,'physical_device_write',     NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (16,'physical_device_delete',    NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (17,'physical_location_write',   NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (18,'physical_location_delete',  NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (19,'physical_rack_write',       NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (20,'physical_rack_delete',      NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (21,'physical_elevation_write',  NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (22,'physical_elevation_delete', NOW(), NOW(), 'Admin');
+INSERT INTO arsenal.groups VALUES (23,'status_write',              NOW(), NOW(), 'Admin');
 
 # Group permissions that can be assigned to groups
 ###########################################################################


### PR DESCRIPTION
In this PR:

- `groups` became a reserved keyword as of mysql 8, so in order to load data into the `groups` table we need to be explicit about it.
- Added build instructions (modernization issue created: https://github.com/UnblockedByOps/arsenal/issues/28)
- Python 3.8 has been deprecated. Updated mysqlclient to the version required for 3.9 (modernization issue created: https://github.com/UnblockedByOps/arsenal/issues/26)
